### PR TITLE
Make AsyncPlayerChatEvent ignore cancelled event

### DIFF
--- a/src/fr/black_eyes/factionsuuidchat/listeners/ChatListener.java
+++ b/src/fr/black_eyes/factionsuuidchat/listeners/ChatListener.java
@@ -23,7 +23,7 @@ public class ChatListener extends Utils implements Listener {
 	 FileConfiguration lang = Main.getConfigFiles().getLang();
 	
 	
-	@EventHandler
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void format(AsyncPlayerChatEvent e) {
 		if(Main.isFactionOn ) {
 			if(FactionsUtils.isFactionChat(e.getPlayer())) return;


### PR DESCRIPTION
This will fix issues with other chat plugins. #1

Maybe priority should be other one, I chose HIGHEST as from what I read in your code you are cancelling the event.